### PR TITLE
Only join actuals to vehicle datapoints on same service day

### DIFF
--- a/subway_prediction_ml/actuals_adder.py
+++ b/subway_prediction_ml/actuals_adder.py
@@ -14,26 +14,42 @@ class ActualsAdder(BaseEstimator, TransformerMixin):
     # Join actuals to a set of vehicle datapoints
     def transform(self, vehicle_datapoints, y=None):
         actuals = self._load_actuals()
+
         vehicle_datapoints["gtfs_trip_id"] = \
             vehicle_datapoints["gtfs_trip_id"].astype(str)
+        vehicle_datapoints["timestamp"] = \
+            vehicle_datapoints["timestamp"].apply(
+                lambda str: datetime.datetime.strptime(
+                    str,
+                    "%Y-%m-%dT%H:%M:%S.%fZ"
+                ).replace(tzinfo=pytz.UTC).timestamp()
+            )
+        self._add_service_date(actuals, 'time')
+        self._add_service_date(vehicle_datapoints, 'timestamp')
 
         merged_frame = vehicle_datapoints.merge(
             actuals,
             how="inner",
-            on='gtfs_trip_id'
-        )
-        merged_frame["timestamp"] = merged_frame["timestamp"].apply(
-            lambda str: datetime.datetime.strptime(
-                str,
-                "%Y-%m-%dT%H:%M:%S.%fZ"
-            ).replace(tzinfo=pytz.UTC).timestamp()
+            on=['gtfs_trip_id', 'service_date']
         )
         merged_frame["actual_seconds_from_now"] = \
             merged_frame["time"] - merged_frame["timestamp"]
-        merged_frame = merged_frame.drop(["timestamp", "time"], axis=1)
+        merged_frame = merged_frame.drop(
+            [
+                "timestamp",
+                "time",
+                'service_date'
+            ], axis=1
+        )
         merged_frame = merged_frame.query("actual_seconds_from_now > 0")
 
         return merged_frame.dropna()
+
+    def _add_service_date(self, dataframe, series_name):
+        dataframe['service_date'] = dataframe[series_name].apply(
+            self._service_date_for_timestamp
+        )
+        return dataframe
 
     # Build a dataframe from prediction analyzer logs, dropping actuals without
     # times, commuter rail trips, and duplicates (which we get because we log
@@ -54,3 +70,15 @@ class ActualsAdder(BaseEstimator, TransformerMixin):
         subway_actuals["gtfs_trip_id"] = \
             subway_actuals["gtfs_trip_id"].astype(str)
         return subway_actuals
+
+    def _service_date_for_timestamp(self, timestamp):
+        # Service days run 3 AM to 3 AM, so adjust the time by 3 hours
+        adjusted_timestamp = timestamp - 10800
+        utc_adjusted_time = datetime. \
+            datetime. \
+            utcfromtimestamp(adjusted_timestamp). \
+            replace(tzinfo=pytz.UTC)
+        adjusted_time = utc_adjusted_time.astimezone(
+            pytz.timezone('America/New_York')
+        )
+        return adjusted_time.toordinal()

--- a/subway_prediction_ml/actuals_adder.py
+++ b/subway_prediction_ml/actuals_adder.py
@@ -14,11 +14,6 @@ class ActualsAdder(BaseEstimator, TransformerMixin):
     # Join actuals to a set of vehicle datapoints
     def transform(self, vehicle_datapoints, y=None):
         actuals = self._load_actuals()
-        actuals = actuals.rename(
-            {"trip_id": "gtfs_trip_id", "stop_id": "destination_gtfs_id"},
-            axis="columns"
-        )
-        actuals["gtfs_trip_id"] = actuals["gtfs_trip_id"].astype(str)
         vehicle_datapoints["gtfs_trip_id"] = \
             vehicle_datapoints["gtfs_trip_id"].astype(str)
 
@@ -51,4 +46,11 @@ class ActualsAdder(BaseEstimator, TransformerMixin):
         raw_frame['stop_id'] = raw_frame['stop_id'].astype('str')
         dropped_frame = raw_frame.dropna(subset=["time"])
         is_subway = dropped_frame["trip_id"].apply(lambda x: x[0:3] != "CR-")
-        return dropped_frame[is_subway].drop_duplicates()
+        subway_actuals = dropped_frame[is_subway].drop_duplicates()
+        subway_actuals = subway_actuals.rename(
+            {"trip_id": "gtfs_trip_id", "stop_id": "destination_gtfs_id"},
+            axis="columns"
+        )
+        subway_actuals["gtfs_trip_id"] = \
+            subway_actuals["gtfs_trip_id"].astype(str)
+        return subway_actuals

--- a/subway_prediction_ml/test/test_actuals_adder.py
+++ b/subway_prediction_ml/test/test_actuals_adder.py
@@ -47,3 +47,24 @@ class TestActualsAdder(unittest.TestCase):
             ['B-112', '70102', 9790.0],
             ['B-112', '70104', 9850.0],
         ]
+
+    def test_only_join_data_on_same_service_date(self):
+        three_am = 1559804400 # June 6, 2019, 3:00 AM
+
+        actuals_data = pd.DataFrame(
+            columns=['trip_id', 'stop_id', 'time'],
+            data=[
+                ['B-111', '70000', three_am - 1],
+            ]
+        )
+
+        vehicle_data = pd.DataFrame(
+            columns=['gtfs_trip_id', 'timestamp'],
+            data=[
+                ['B-111', "2019-06-06T07:00:00.000000Z"],
+            ]
+        )
+
+        adder = ActualsAdder(actuals_data)
+        result = adder.fit_transform(vehicle_data).__array__().tolist()
+        assert sorted(result) == []


### PR DESCRIPTION
GTFS IDs get re-used but are unique per service day, from 3 AM to 3 AM. Ensure when joining vehicle datapoints to actuals that we only join points on the same service day.